### PR TITLE
De-emphasize and italicize comment colors

### DIFF
--- a/synthwave-x-fluoromachine.css
+++ b/synthwave-x-fluoromachine.css
@@ -4,6 +4,11 @@
   text-shadow: 0 0 2px #001716, 0 0 5px #03edf933, 0 0 10px #ffff6633;
 }
 
+.mtk3.mtki {
+  font-style: italic;
+  color: #495495;
+}
+
 .mtk4, .mtk5, .mtk14 {
   color: #9963ff;
 }


### PR DESCRIPTION
Targets `.mtk3.mtki` to make comments different than the rest of the text.